### PR TITLE
Adding partial binding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,31 @@ Multiple infix syntaxes are provided by the ``infix`` module::
     ...
     >>> print(3 **pow** 2)
     9
+    
+    >>> dpow = div_infix(pow)
+    >>> print(3 /dpow/ 2)
+    9
 
 Custom syntaxes
 ----------------
 
-Python has a large set of operators than could be overridden to provide the infix syntax, so instead of providing them all a ``custom_infix`` function is provided. It takes two parameters, the names of the left and right operator functions::
+Python has a large set of operators than could be overridden to provide the infix syntax, so instead of providing them all a ``make_infix`` function is provided. To use it, pass the names of the operatorsyou want to support::
+
+    >>> @make_infix('mod','pow','rshift')
+    ... def until(start, stop):
+    ...     return range(start, stop)
+    >>> print(1 %until% 3)
+    [1, 2]
+    >>> print(2 <<until>> 4)
+    [2, 3]
+    >>> print(5 **until** 8)
+    [5, 6, 7]
+    >>> print(until(10,12))
+    [10, 11]
+
+.. versionadded:: 1.1
+
+The old ``custom_infix`` is still supported. It takes two parameters, the names of the left and right operator functions, though only the first is important::
 
     >>> @custom_infix('__rmod__', '__mod__')
     ... def ate(a, b):
@@ -75,6 +95,16 @@ Python has a large set of operators than could be overridden to provide the infi
 The left function should be a `right operand <http://docs.python.org/2/reference/datamodel.html#object.__radd__>`_, and the right functions should be a `left operand <http://docs.python.org/2/reference/datamodel.html#object.__add__>`_.
 
 You should be careful to avoid using operands that the objects your functions will take may provide themselves (as the initial right operand is only called if the previous object does not provide for that operand).
+
+Binding
+-------
+
+The library now uses a binding feature to generate a temporary object halfway through the process. That means that half expressions now work::
+
+    >>> 3**pow
+    <pow_lbind: Waiting for right side>
+
+.. versionadded:: 1.1
 
 Compatibility
 -------------

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Python has a large set of operators than could be overridden to provide the infi
 
     >>> @make_infix('mod','pow','rshift')
     ... def until(start, stop):
-    ...     return range(start, stop)
+    ...     return list(range(start, stop))
     >>> print(1 %until% 3)
     [1, 2]
     >>> print(2 <<until>> 4)


### PR DESCRIPTION
This now works with partial binding (and even displays a reasonable `repr`, too). Making new ops is now easier, and several more are provided by default. The old custom_infix is still supported through the new system. As a nice side feature, due to any binding order being supported, the power syntax works without a hack now!